### PR TITLE
feat: accept Intl.DateTimeFormatOptions and callbacks in format()

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ The callback receives `(timestamp: number, context: { locale?: string; timeZone:
 
 > **Note on ISO weeks:** Use `yearOfWeek` (not `year`) when displaying week numbers — ISO week years don't always match the calendar year near New Year (e.g. 2022-01-01 is W52 of week-year 2021).
 
-> **Note on TypeScript:** Chart.js types `displayFormats` values as `string`. Non-string format values work at runtime (Chart.js passes them through to the adapter without validation), but you may need a type assertion in strict TypeScript.
+> **Note on TypeScript:** Chart.js types `displayFormats` values as `string`. Non-string format values work at runtime (Chart.js passes them through to the adapter without validation), but you may need a type assertion in strict TypeScript. See [chartjs/Chart.js#12220](https://github.com/chartjs/Chart.js/issues/12220).

--- a/README.md
+++ b/README.md
@@ -35,3 +35,54 @@ Or use the `register` import:
 ```ts
 import 'chartjs-adapter-temporal/register';
 ```
+
+## Custom display formats
+
+Chart.js passes `displayFormats` values directly to the adapter's `format()` method. In addition to the built-in string keys (`'datetime'`, `'day'`, `'week'`, etc.), you can use:
+
+### Intl.DateTimeFormatOptions objects
+
+Pass formatting options directly — no need for predefined keys:
+
+```ts
+scales: {
+  x: {
+    type: 'time',
+    time: {
+      displayFormats: {
+        day: { weekday: 'short' },
+        month: { month: 'short' },
+      },
+    },
+  },
+}
+```
+
+### Callback functions
+
+For formatting that Intl can't reliably do (e.g. ISO week numbers), use a callback:
+
+```ts
+scales: {
+  x: {
+    type: 'time',
+    time: {
+      displayFormats: {
+        week: (timestamp, { timeZone }) => {
+          const date = Temporal.Instant.fromEpochMilliseconds(timestamp)
+            .toZonedDateTimeISO(timeZone)
+            .toPlainDate();
+          const week = String(date.weekOfYear!).padStart(2, '0');
+          return `${date.yearOfWeek}-W${week}`;
+        },
+      },
+    },
+  },
+}
+```
+
+The callback receives `(timestamp: number, context: { locale?: string; timeZone: string })` and should return a string.
+
+> **Note on ISO weeks:** Use `yearOfWeek` (not `year`) when displaying week numbers — ISO week years don't always match the calendar year near New Year (e.g. 2022-01-01 is W52 of week-year 2021).
+
+> **Note on TypeScript:** Chart.js types `displayFormats` values as `string`. Non-string format values work at runtime (Chart.js passes them through to the adapter without validation), but you may need a type assertion in strict TypeScript.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,22 @@ export interface AdapterOptions {
   timeZone?: string;
 }
 
+export interface FormatContext {
+  locale?: string;
+  timeZone: string;
+}
+
+export type FormatValue =
+  | string
+  | Intl.DateTimeFormatOptions
+  | ((timestamp: number, context: FormatContext) => string);
+
+declare module 'chart.js' {
+  interface DateAdapter<T extends Record<string, any> = Record<string, any>> {
+    format(this: DateAdapter<T>, timestamp: number, format: FormatValue): string;
+  }
+}
+
 const FORMAT_OPTIONS: Record<
   string,
   Intl.DateTimeFormatOptions & { fractionalSecondDigits?: number }
@@ -75,6 +91,10 @@ const adapter: DateAdapter<AdapterOptions> = {
   format(timestamp, format) {
     const timeZone = getTimeZone(this.options);
 
+    if (typeof format === 'function') {
+      return format(timestamp, { locale: this.options.locale, timeZone });
+    }
+
     if (format === FORMATS.quarter) {
       const q =
         Math.floor(
@@ -83,14 +103,12 @@ const adapter: DateAdapter<AdapterOptions> = {
       return `Q${q} - ${this.format(timestamp, FORMATS.year as any)}`;
     }
 
-    const key = `${this.options.locale}:${timeZone}:${format}`;
+    const options = typeof format === 'string' ? FORMAT_OPTIONS[format] : format;
+    const key = `${this.options.locale}:${timeZone}:${typeof format === 'string' ? format : JSON.stringify(format)}`;
     let formatter = cache.get(key);
 
     if (!formatter) {
-      formatter = new Intl.DateTimeFormat(this.options.locale, {
-        ...FORMAT_OPTIONS[format],
-        timeZone,
-      });
+      formatter = new Intl.DateTimeFormat(this.options.locale, { ...options, timeZone });
       cache.set(key, formatter);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,12 +15,6 @@ export type FormatValue =
   | Intl.DateTimeFormatOptions
   | ((timestamp: number, context: FormatContext) => string);
 
-declare module 'chart.js' {
-  interface DateAdapter<T extends Record<string, any> = Record<string, any>> {
-    format(this: DateAdapter<T>, timestamp: number, format: FormatValue): string;
-  }
-}
-
 const FORMAT_OPTIONS: Record<
   string,
   Intl.DateTimeFormatOptions & { fractionalSecondDigits?: number }
@@ -88,7 +82,8 @@ const adapter: DateAdapter<AdapterOptions> = {
     return FORMATS;
   },
 
-  format(timestamp, format) {
+  format(timestamp, _format) {
+    const format = _format as FormatValue;
     const timeZone = getTimeZone(this.options);
 
     if (typeof format === 'function') {

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,4 +1,20 @@
-import { _adapters } from 'chart.js';
+import { _adapters, defaults } from 'chart.js';
 import adapter from './';
 
 _adapters._date.override(adapter);
+
+// displayFormats values may be functions or Intl.DateTimeFormatOptions (FormatValue),
+// handled by the adapter — not Chart.js scriptable options. Without this,
+// Chart.js calls function values with the chart context object instead of
+// letting the adapter call them with a numeric timestamp.
+// We set _scriptable directly on the defaults object (not via defaults.describe)
+// because the resolver reads _scriptable from the scope chain, not from the
+// separate _descriptors tree.
+defaults.set('scales.time', {
+  time: {
+    displayFormats: {
+      _scriptable: false,
+      _indexable: false,
+    },
+  },
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -134,6 +134,40 @@ describe('chart.js temporal adapter', () => {
         'May 28, 2019, 3:10:27 PM',
       );
     });
+
+    test('should format with Intl.DateTimeFormatOptions object', () => {
+      const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
+      const result = adapter.format(timestamp, { weekday: 'short' });
+      expect(result).toMatch(/^Di\.?$/);
+    });
+
+    test('should format with Intl.DateTimeFormatOptions object respecting locale', () => {
+      adapter = new _adapters._date({ locale: 'en-US', timeZone: 'Europe/Berlin' });
+      const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
+      const result = adapter.format(timestamp, { month: 'short', day: 'numeric' });
+      expect(result).toEqual('May 28');
+    });
+
+    test('should format with callback function', () => {
+      const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
+      const result = adapter.format(timestamp, (ts, { timeZone }) => {
+        const date = Temporal.Instant.fromEpochMilliseconds(ts)
+          .toZonedDateTimeISO(timeZone)
+          .toPlainDate();
+        const week = String(date.weekOfYear!).padStart(2, '0');
+        return `${date.yearOfWeek}-W${week}`;
+      });
+      expect(result).toEqual('2019-W22');
+    });
+
+    test('should pass locale and timeZone to callback function', () => {
+      adapter = new _adapters._date({ locale: 'en-US', timeZone: 'America/New_York' });
+      const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
+      const result = adapter.format(timestamp, (_ts, ctx) => {
+        return `${ctx.locale}|${ctx.timeZone}`;
+      });
+      expect(result).toEqual('en-US|America/New_York');
+    });
   });
 
   describe('add', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -137,35 +137,41 @@ describe('chart.js temporal adapter', () => {
 
     test('should format with Intl.DateTimeFormatOptions object', () => {
       const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
-      const result = adapter.format(timestamp, { weekday: 'short' });
+      const result = adapter.format(timestamp, { weekday: 'short' } as any);
       expect(result).toMatch(/^Di\.?$/);
     });
 
     test('should format with Intl.DateTimeFormatOptions object respecting locale', () => {
       adapter = new _adapters._date({ locale: 'en-US', timeZone: 'Europe/Berlin' });
       const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
-      const result = adapter.format(timestamp, { month: 'short', day: 'numeric' });
+      const result = adapter.format(timestamp, { month: 'short', day: 'numeric' } as any);
       expect(result).toEqual('May 28');
     });
 
     test('should format with callback function', () => {
       const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
-      const result = adapter.format(timestamp, (ts, { timeZone }) => {
+      const result = adapter.format(timestamp, ((
+        ts: number,
+        { timeZone }: { timeZone: string },
+      ) => {
         const date = Temporal.Instant.fromEpochMilliseconds(ts)
           .toZonedDateTimeISO(timeZone)
           .toPlainDate();
         const week = String(date.weekOfYear!).padStart(2, '0');
         return `${date.yearOfWeek}-W${week}`;
-      });
+      }) as any);
       expect(result).toEqual('2019-W22');
     });
 
     test('should pass locale and timeZone to callback function', () => {
       adapter = new _adapters._date({ locale: 'en-US', timeZone: 'America/New_York' });
       const timestamp = adapter.parse('2019-05-28T15:10:27.000Z')!;
-      const result = adapter.format(timestamp, (_ts, ctx) => {
+      const result = adapter.format(timestamp, ((
+        _ts: number,
+        ctx: { locale?: string; timeZone: string },
+      ) => {
         return `${ctx.locale}|${ctx.timeZone}`;
-      });
+      }) as any);
       expect(result).toEqual('en-US|America/New_York');
     });
   });


### PR DESCRIPTION
- `format()` now accepts `Intl.DateTimeFormatOptions` objects directly (e.g. `{ weekday: 'short' }`)
- `format()` now accepts callback functions `(timestamp, { locale, timeZone }) => string` for formatting Intl can't express (e.g. ISO week numbers)
- All existing string keys work exactly as before — fully backwards compatible

### Motivation

  The built-in format presets cover common cases, but users who need different Intl options (e.g. short weekday, month-only) or non-Intl formatting (e.g. ISO week numbers via `Temporal.PlainDate.weekOfYear`)
  currently have no way to customize without wrapping or forking the adapter.

  Since Chart.js passes `displayFormats` values straight through to `adapter.format()` without validation, the adapter can accept richer types at runtime:

  ```ts
  displayFormats: {
    day: { weekday: 'short' },
    week: (timestamp, { timeZone }) => {
      const date = Temporal.Instant.fromEpochMilliseconds(timestamp)
        .toZonedDateTimeISO(timeZone).toPlainDate();
      return `${date.yearOfWeek}-W${String(date.weekOfYear!).padStart(2, '0')}`;
    },
  }
  ```

### TypeScript note

Chart.js types displayFormats as `{ [key: string]: string }`, so non-string values require a type assertion until https://github.com/chartjs/Chart.js/issues/12220 is resolved. FormatValue and FormatContext are exported for consumers who want to type their callbacks.

Cowritten by claude