### PR TITLE
fix: list dist/register.mjs in sideEffects array (was register.js, which doesn't exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   ],
   "type": "module",
   "sideEffects": [
-    "dist/register.js",
-    "dist/register.cjs"
+    "dist/register.cjs",
+    "dist/register.mjs"
   ],
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
The `sideEffects` array in `package.json` references `dist/register.js`, but the build emits `dist/register.mjs` and `dist/register.cjs` (as declared in `exports["./register"]`). `register.js` doesn't exist in the published package — see [npm v1.2.2 file listing][1] (or run `pnpm exec publint` on a fresh clone, which flags it).                                                                                                                                                             
                                                                                                                                                                                                                     
  ```diff                                                                                                                                                                                                            
     "sideEffects": [                                                                                                                                                                                                
  -    "dist/register.js", 
  +    "dist/register.mjs"                                                                                                                                                                                          
       "dist/register.cjs",                                                                                                                                                                                                                           
     ],
```                                                                                                                                                                                                                  
  
  So the array gets it wrong in both directions:
  - Superfluous: dist/register.js — listed but not shipped.                                                                                                                                                          
  - Missing: dist/register.mjs — shipped, but not listed.   
                                                                                                                                                                                                                     
  ## Why it matters                              
                                                                                                                                                                                                                     
Bundlers that resolve the ESM entry to dist/register.mjs (Vite, Rollup, modern webpack) check the sideEffects whitelist and don't find register.mjs there, so they treat the file as side-effect-free. With aggressive tree-shaking enabled (production builds), the  side-effect-only `import 'chartjs-adapter-temporal/register'` gets dropped from the bundle. _adapters._date.override(adapter) never runs, and Chart.js throws at first chart render:                                                                                                                                                             
                                                                                                                                                                                                                     
> Error: This method is not implemented: Check that a complete date adapter is provided.                                                                                                                           
                                                                                                                                                                                                                     
Dev builds keep working because tree-shaking is disabled there, so the regression only appears on deploy.
  
  
### [Reproduction of actual files in /dist:](https://www.npmjs.com/package/chartjs-adapter-temporal?activeTab=versions)
<img width="794" height="720" alt="Screenshot 2026-05-06 at 13 46 22" src="https://github.com/user-attachments/assets/2fbf1c94-d5d5-4c07-bacb-f6796ec9036a" />

 
  
  
  